### PR TITLE
Rename old references of Ubuntu 18 to 20 in Docs and Comments

### DIFF
--- a/modules/nodes-config-re/provisioning_re_node.tf
+++ b/modules/nodes-config-re/provisioning_re_node.tf
@@ -1,6 +1,6 @@
-#### Generating Ansible config, inventory, playbook 
+#### Generating Ansible config, inventory, playbook
 #### and configuring RE nodes and installing RE software
-#### (RE nodes need special configuration to work with Ubuntu 18)
+#### (RE nodes need special configuration to work with Ubuntu 20)
 
 #### TESTING
 # Define a null_resource block for the retry logic
@@ -52,7 +52,7 @@ resource "null_resource" "remote-config" {
 #### otherwise it can run to fast, not find the inventory file and fail or hang
 resource "time_sleep" "wait_30_seconds_re" {
   create_duration = "30s"
-  depends_on = [local_file.inventory-setup, 
+  depends_on = [local_file.inventory-setup,
                 local_file.ssh-setup]
 }
 

--- a/modules/nodes-config-re/variables.tf
+++ b/modules/nodes-config-re/variables.tf
@@ -19,8 +19,8 @@ variable "vpc_name" {
 
 ############## Redis Enterprise Nodes Variables
 
-#### RE Software download url (MUST BE ubuntu 18.04)
-#### example: re_download_url = "https://s3.amazonaws.com/redis-enterprise-software-downloads/x.x.xx/redislabs-x.x.xx-68-bionic-amd64.tar"
+#### RE Software download url (MUST BE ubuntu 20.04)
+#### example: re_download_url = "https://s3.amazonaws.com/redis-enterprise-software-downloads/x.x.xx/redislabs-x.x.xx-xxx-focal-amd64.tar"
 variable "re_download_url" {
   description = "re download url"
   default     = ""

--- a/modules/nodes/inputs.tf
+++ b/modules/nodes/inputs.tf
@@ -1,11 +1,8 @@
 #### AMI for Nodes
-#### find the lastest ami for ubuntu 18.04 x86 server
 #### find the ami for ubuntu 20.04 x86 server
 
-#ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240321
+# ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240321
 # "ubuntu\\/images\\/hvm-ssd\\/ubuntu-focal-20.04-amd64-server-20240321"
-#old 18.04
-# "ubuntu\\/images\\/hvm-ssd\\/ubuntu-bionic-18.04-amd64-server"
 data "aws_ami" "ami" {
   most_recent = true
   name_regex  = "ubuntu\\/images\\/hvm-ssd\\/ubuntu-focal-20.04-amd64-server-20240321"

--- a/modules/nodes/inputs.tf
+++ b/modules/nodes/inputs.tf
@@ -5,7 +5,7 @@
 # "ubuntu\\/images\\/hvm-ssd\\/ubuntu-focal-20.04-amd64-server-20240321"
 data "aws_ami" "ami" {
   most_recent = true
-  name_regex  = "ubuntu\\/images\\/hvm-ssd\\/ubuntu-focal-20.04-amd64-server-20240321"
+  name_regex  = "ubuntu\\/images\\/hvm-ssd\\/ubuntu-focal-20.04-amd64-server-*"
   # This is Canonical's ID (find here: https://ubuntu.com/server/docs/cloud-images/amazon-ec2)
   owners = ["099720109477"]
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,10 +1,10 @@
 #### User Input Required
 #### Enter your user variables here
-#### Some variables have default values and if you do not specify 
+#### Some variables have default values and if you do not specify
 
 #### User Input Required
 #### Access key and Secret key for aws account [AWS_ACCESS_KEY, AWS_SECRET_KEY]
-#### (fake example: aws_creds = ["myAccesssKeyxjdklfdakf","MySecretKeyxkldkfhadjkfh"]) 
+#### (fake example: aws_creds = ["myAccesssKeyxjdklfdakf","MySecretKeyxkldkfhadjkfh"])
 aws_creds =
 
 #### User Input Required
@@ -22,7 +22,7 @@ ssh_key_path =
 #### User Input Required
 #### If you do not have one already, go get a domain name on Route53
 #### DNS hosted zone id (find value in R53 hosted zones)
-### navigate to Route 53 in the AWS console, click hosted zones, 
+### navigate to Route 53 in the AWS console, click hosted zones,
 ### find hosted zone "domain name" of interest, use its "hosted zone ID" (fake example: dns_hosted_zone_id="Z903232kljadfdk")
 dns_hosted_zone_id =
 
@@ -34,7 +34,7 @@ owner = "redisuser"
 #### example: region = "us-west-2"
 region = "us-west-2"
 
-#### Base Name of Resources 
+#### Base Name of Resources
 #### (Resource prefix for all generated resources)
 #### default = "redisuser1-tf"
 base_name = "redis-tf"
@@ -44,11 +44,11 @@ base_name = "redis-tf"
 #### example: vpc_cidr = ""10.0.0.0/16""
 vpc_cidr = "10.0.0.0/16"
 
-#### Subnet CIDR Block 
+#### Subnet CIDR Block
 #### example: subnet_cidr_blocks = ["10.0.0.0/24","10.0.16.0/24","10.0.32.0/24"]
 subnet_cidr_blocks = ["10.0.0.0/24","10.0.16.0/24","10.0.32.0/24"]
 
-#### Subnet AZ 
+#### Subnet AZ
 #### example: subnet_azs = ["us-west-2a","us-west-2b","us-west-2c"]
 subnet_azs = ["us-west-2a","us-west-2b","us-west-2c"]
 
@@ -66,8 +66,8 @@ test-node-count = 1
 ############## Redis Enterprise Nodes Variables
 
 #### User Input Required
-#### RE Software download url (MUST BE ubuntu 18.04)
-#### (FAKE example (update the x.x.xx with the Redis Software version!): re_download_url = "https://s3.amazonaws.com/redis-enterprise-software-downloads/x.x.xx/redislabs-x.x.xx-68-bionic-amd64.tar")
+#### RE Software download url (MUST BE ubuntu 20.04)
+#### (FAKE example (update the x.x.xx with the Redis Software version!): re_download_url = "https://s3.amazonaws.com/redis-enterprise-software-downloads/x.x.xx/redislabs-x.x.xx-xxx-focal-amd64.tar")
 re_download_url =
 
 #### RE cluster options


### PR DESCRIPTION
I was going through the setup of a cluster and got a but confused of references of ubuntu 18 still present in the comments so i renamed all references of the old version left out.